### PR TITLE
Removed some usage of boost.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,8 @@ include(ExternalProject)
 ExternalProject_Add(
 	fastlib
 	GIT_REPOSITORY git@github.com:fast-project/fast-lib.git
-	CMAKE_ARGS -DCMAKE_CXX_FLAGS=-fpic -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DUSE_BOOST_CACHE=ON -DBOOST_CACHE_DIR=${BOOST_CACHE_DIR}
+	CMAKE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} cmake
+	CMAKE_ARGS -DCMAKE_CXX_FLAGS=-fpic -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 )
 ExternalProject_Get_Property(fastlib install_dir)
 include_directories("${install_dir}/include")
@@ -54,6 +55,7 @@ ExternalProject_Add(
 	libssh
 	GIT_REPOSITORY http://git.libssh.org/projects/libssh.git
 	GIT_TAG libssh-0.7.2
+	CMAKE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} cmake
 	CMAKE_ARGS -DWITH_ZLIB=OFF -DWITH_SFTP=OFF -DWITH_PCAP=OFF -DWITH_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 )
 ExternalProject_Get_Property(libssh install_dir)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,16 +33,14 @@ set(BOOST_CACHE_DIR ${PROJECT_BINARY_DIR})
 include(add_boost)
 include_directories(SYSTEM ${BoostSourceDir})
 list(APPEND LIBS "${BoostProgramOptionsLibs}" "${BoostPropertyTreeLibs}" "${BoostRegexLibs}")
-#list(APPEND LIBS "${BoostProgramOptionsLibs}" "${BoostLogLibs}" "${BoostChronoLibs}" "${BoostDateTimeLibs}" "${BoostFilesystemLibs}" "${BoostThreadLibs}" "${BoostSystemLibs}" "${BoostPropertyTreeLibs}" "${BoostRegexLibs}" "${BoostTimerLibs}")
-list(APPEND LIBS_BENCHMARK "${BoostProgramOptionsLibs}" "${BoostLogLibs}" "${BoostChronoLibs}" "${BoostDateTimeLibs}" "${BoostFilesystemLibs}" "${BoostThreadLibs}" "${BoostSystemLibs}" "${BoostPropertyTreeLibs}" "${BoostRegexLibs}")
+list(APPEND LIBS_BENCHMARK "${BoostProgramOptionsLibs}" "${BoostPropertyTreeLibs}" "${BoostRegexLibs}")
 
 # fast-lib
 include(ExternalProject)
 ExternalProject_Add(
 	fastlib
-#	GIT_REPOSITORY git@github.com:fast-project/fast-lib.git
-	GIT_REPOSITORY git@github.com:timohl/fast-lib.git
-	GIT_TAG no-boost
+	GIT_REPOSITORY git@github.com:fast-project/fast-lib.git
+	GIT_TAG master
 	CMAKE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} cmake
 	CMAKE_ARGS -DCMAKE_CXX_FLAGS=-fpic -DBUILD_SHARED_LIBS=OFF -DENABLE_LOGGING=ON -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 )
@@ -77,8 +75,6 @@ else()
 
 	message(SEND_ERROR "libvirt is required.")
 endif()
-#include_directories(SYSTEM /global/cluster/libvirt-1.2.16/include)
-#list(APPEND LIBS "/global/cluster/libvirt-1.2.16/lib/libvirt.so")
 
 ### Define source files.
 set(SRC ${PROJECT_SOURCE_DIR}/src/main.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,16 +32,19 @@ set(USE_BOOST_CACHE ON)
 set(BOOST_CACHE_DIR ${PROJECT_BINARY_DIR})
 include(add_boost)
 include_directories(SYSTEM ${BoostSourceDir})
-list(APPEND LIBS "${BoostProgramOptionsLibs}" "${BoostLogLibs}" "${BoostChronoLibs}" "${BoostDateTimeLibs}" "${BoostFilesystemLibs}" "${BoostThreadLibs}" "${BoostSystemLibs}" "${BoostPropertyTreeLibs}" "${BoostRegexLibs}" "${BoostTimerLibs}")
+list(APPEND LIBS "${BoostProgramOptionsLibs}" "${BoostPropertyTreeLibs}" "${BoostRegexLibs}")
+#list(APPEND LIBS "${BoostProgramOptionsLibs}" "${BoostLogLibs}" "${BoostChronoLibs}" "${BoostDateTimeLibs}" "${BoostFilesystemLibs}" "${BoostThreadLibs}" "${BoostSystemLibs}" "${BoostPropertyTreeLibs}" "${BoostRegexLibs}" "${BoostTimerLibs}")
 list(APPEND LIBS_BENCHMARK "${BoostProgramOptionsLibs}" "${BoostLogLibs}" "${BoostChronoLibs}" "${BoostDateTimeLibs}" "${BoostFilesystemLibs}" "${BoostThreadLibs}" "${BoostSystemLibs}" "${BoostPropertyTreeLibs}" "${BoostRegexLibs}")
 
 # fast-lib
 include(ExternalProject)
 ExternalProject_Add(
 	fastlib
-	GIT_REPOSITORY git@github.com:fast-project/fast-lib.git
+#	GIT_REPOSITORY git@github.com:fast-project/fast-lib.git
+	GIT_REPOSITORY git@github.com:timohl/fast-lib.git
+	GIT_TAG no-boost
 	CMAKE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} cmake
-	CMAKE_ARGS -DCMAKE_CXX_FLAGS=-fpic -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+	CMAKE_ARGS -DCMAKE_CXX_FLAGS=-fpic -DBUILD_SHARED_LIBS=OFF -DENABLE_LOGGING=ON -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 )
 ExternalProject_Get_Property(fastlib install_dir)
 include_directories("${install_dir}/include")

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -11,14 +11,16 @@
 #include "hooks.hpp"
 
 #include <fast-lib/message/migfra/result.hpp>
-
-#include <boost/log/trivial.hpp>
+#include <fast-lib/log.hpp>
 
 #include <exception>
 #include <future>
 #include <utility>
 #include <iostream>
 #include <array>
+
+FASTLIB_LOG_INIT(migfra_task_log, "Task")
+FASTLIB_LOG_SET_LEVEL_GLOBAL(migfra_task_log, trace);
 
 using namespace fast::msg::migfra;
 
@@ -81,7 +83,7 @@ std::future<Result> execute(std::shared_ptr<Task> task,
 						time_measurement);
 			}
 		} catch (const std::exception &e) {
-			BOOST_LOG_TRIVIAL(warning) << "Exception in task: " << e.what();
+			FASTLIB_LOG(migfra_task_log, warning) << "Exception in task: " << e.what();
 			return Result(task->vm_name, "error", time_measurement, e.what());
 		}
 		time_measurement.tock("overall");
@@ -94,7 +96,7 @@ std::future<Result> execute(std::shared_ptr<Task> task,
 void execute(const Task_container &task_cont, std::shared_ptr<Hypervisor> hypervisor, std::shared_ptr<fast::Communicator> comm)
 {
 	if (task_cont.tasks.empty()) {
-		BOOST_LOG_TRIVIAL(warning) << "Empty task container executed.";
+		FASTLIB_LOG(migfra_task_log, warning) << "Empty task container executed.";
 		return;
 	}
 	/// \todo In C++14 unique_ptr for sub_tasks and init capture to move in lambda should be used!


### PR DESCRIPTION
As fast-lib is now independent of boost, the boost path does not have to be passed.
Furthermore, the logging facility of fast-lib is now used instead of boost.log.
