### PR TITLE
Added daemon and logfile options and check for other instances.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,8 @@
 
 #include "task_handler.hpp"
 
+#include "utility.hpp"
+
 #include <boost/program_options.hpp>
 #include <mosquittopp.h>
 
@@ -16,6 +18,10 @@
 #include <string>
 #include <exception>
 #include <iostream>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
 
 int main(int argc, char *argv[])
 {
@@ -25,6 +31,7 @@ int main(int argc, char *argv[])
 		po::options_description desc("Options");
 		desc.add_options()
 			("help", "produce help message")
+			("daemon,d", "start as daemon")
 			("config", po::value<std::string>(), "path to config file");
 		po::variables_map vm;
 		po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -36,6 +43,34 @@ int main(int argc, char *argv[])
 		std::string config_file_name = "migfra.conf";
 		if (vm.count("config"))
 			config_file_name = vm["config"].as<std::string>();
+		config_file_name = convert_and_free_cstr(realpath(config_file_name.c_str(), nullptr));
+		if (vm.count("daemon")) {
+			std::cout << "Starting migfra daemon." << std::endl;
+			pid_t pid;
+			pid_t sid;
+			pid = fork();
+			if (pid < 0)
+				return EXIT_FAILURE;
+			if (pid > 0)
+				exit(EXIT_SUCCESS);
+			umask(0);
+			sid = setsid();
+			if (sid < 0)
+				return EXIT_FAILURE;
+			if (chdir("/") < 0)
+				return EXIT_FAILURE;
+			//TODO redirect stdout to syslog
+/*			dup2(fileno(someopenfile), STDIN_FILENO);
+			dup2(fileno(someotherfile), STDOUT_FILENO);
+			dup2(fileno(somethirdopenfile), STDERR_FILENO);
+			fclose(someopenfile);
+			fclose(someotheropenfile);
+			fclose(somethirdopenfile);
+*/
+			close(STDIN_FILENO);
+			close(STDOUT_FILENO);
+			close(STDERR_FILENO);
+		}
 		Task_handler task_handler(config_file_name);
 		std::cout << "Debug: task_handler loop started." << std::endl;
 		task_handler.loop();


### PR DESCRIPTION
`migfra -l <logfile>` allows to specify a logfile to which stdout/stderr/stdlog are redirected to.
`migfra -d` allows to start as a daemon, i.e., the process is put in the background and stdout/stderr/stdlog are closed if not previously redirected to a logfile.
Also the migration-framework checks if another instance is running on the same machine by creating and locking the file `/tmp/migfra.pid`.

Fixes #29.
